### PR TITLE
Fix panic when "real" zipkin is unavailable.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -142,6 +142,7 @@ func (m *Mirror) runWorker() {
 		resp, err := client.Do(r)
 		if err != nil {
 			logrus.WithError(err).Info("Error sending payload downstream")
+			continue
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusAccepted {


### PR DESCRIPTION
Zipkinproxy can be configured to mirror all the data it receives to an actual
Zipkin installation. Unfortunately, faulty error handling would cause the 
zipkinproxy to panic if it couldn't connect to the real Zipkin. Fix that.