### PR TITLE
Don't concatenate span name and tags when creating Honeycomb events

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -208,14 +208,14 @@ func TestHoneycombOutput(t *testing.T) {
 	assert.Equal(len(mockHoneycomb.Events()), 1)
 	assert.Equal(mockHoneycomb.Events()[0].Fields(),
 		map[string]interface{}{
-			"traceId":                "350565b6a90d4c8c",
-			"name":                   "persist",
-			"id":                     "34472e70cb669b31",
-			"serviceName":            "poodle",
-			"hostIPv4":               "10.129.211.111",
-			"persist.lc":             "poodle",
-			"persist.responseLength": "136",
-			"durationMs":             0.192,
+			"traceId":        "350565b6a90d4c8c",
+			"name":           "persist",
+			"id":             "34472e70cb669b31",
+			"serviceName":    "poodle",
+			"hostIPv4":       "10.129.211.111",
+			"lc":             "poodle",
+			"responseLength": "136",
+			"durationMs":     0.192,
 		})
 }
 

--- a/sinks/honeycomb.go
+++ b/sinks/honeycomb.go
@@ -43,7 +43,7 @@ func (hs *HoneycombSink) Send(spans []*types.Span) error {
 		ev.Timestamp = s.Timestamp
 		ev.Add(s.CoreSpanMetadata)
 		for k, v := range s.BinaryAnnotations {
-			ev.AddField(fmt.Sprintf("%s.%s", s.Name, k), v)
+			ev.AddField(k, v)
 		}
 		err := ev.Send()
 		if err != nil {


### PR DESCRIPTION
Previously, if you instrumented your code with something like
```
span, _ := opentracing.StartSpanFromContext(ctx, "mySpanName")
span.SetTag("userId", 22)
```
then zipkinproxy would emit Honeycomb events containing the field
```
{"mySpanName.userId": 22, ...}
```

The idea was that by including the span name, it'd be clearer where each
column was coming from in code. But from our internal use, this seems to
have more downsides than upsides: If you rename a span, it messes with
your trace dataset's schema. And if you have metadata that's
intentionally shared across spans, this scheme isn't very helpful (for
example, https://honeycomb.phacility.com/D1424 adds the query run PK to
all spans, but it's not helpful to have columns
`processSegment.queryRunPK`, `ReadRows,queryRunPK`, etc.).

So stop doing this, and just use the span tag as the Honeycomb field
name (e.g., `{"userId": 22, ...}`).