### PR TITLE
Propagate sample rate in honeycomb events

### DIFF
--- a/sinks/honeycomb.go
+++ b/sinks/honeycomb.go
@@ -9,6 +9,7 @@ import (
 )
 
 const datasetKey = "honeycomb.dataset"
+const sampleRateKey = "honeycomb.samplerate"
 
 // HoneycombSink implements the Sink interface. It sends spans to the Honeycomb
 // API.
@@ -45,23 +46,54 @@ spanLoop:
 		ev.Timestamp = s.Timestamp
 		ev.Add(s.CoreSpanMetadata)
 		for k, v := range s.BinaryAnnotations {
-			if k == datasetKey {
+			switch k {
+			case datasetKey:
 				// Let clients route spans to different datasets using the
 				// `honeycomb.dataset` tag.
-				ds, ok := v.(string)
-				if !ok {
-					logrus.WithField("honeycomb.dataset", v).Error("unexpected type for honeycomb.dataset tag value")
+				if ds, ok := v.(string); ok {
+					ev.Dataset = ds
+				} else {
+					logrus.WithField("honeycomb.dataset", v).Error(
+						"unexpected type for honeycomb.dataset tag value")
 					continue spanLoop
 				}
-				ev.Dataset = ds
-			} else {
+			case sampleRateKey:
+				if sampleRate, ok := extractUint(v); ok {
+					ev.SampleRate = sampleRate
+				} else {
+					logrus.WithField(sampleRateKey, v).Error(
+						"unexpected value for honeycomb.samplerate tag")
+					// Let's not drop on invalid sample rate though
+				}
+			default:
 				ev.AddField(k, v)
 			}
 		}
-		err := ev.Send()
+		err := ev.SendPresampled()
 		if err != nil {
 			logrus.WithError(err).Info("Error sending libhoney event")
 		}
 	}
 	return nil
+}
+
+// Extract an unsigned int from an interface{} type if possible, so that we can
+// get a samplerate value from a span tag.
+// This implementation relies on us having converted annotation values of string
+// type to int64 or float64 values in guessAnnotationType().
+func extractUint(v interface{}) (uint, bool) {
+	switch val := v.(type) {
+	case int64:
+		if val < 0 {
+			return 0, false
+		}
+		return uint(val), true
+	case float64:
+		if val < 0 {
+			return 0, false
+		}
+		return uint(val), true
+	default:
+		return 0, false
+	}
 }

--- a/types/json.go
+++ b/types/json.go
@@ -8,7 +8,7 @@ import (
 // DecodeJSON reads an array of JSON-encoded spans from an io.Reader, and
 // converts that array to a slice of Spans.
 func DecodeJSON(r io.Reader) ([]*Span, error) {
-	var jsonSpans []zipkinJSONSpan
+	var jsonSpans []ZipkinJSONSpan
 	err := json.NewDecoder(r).Decode(&jsonSpans)
 	if err != nil {
 		return nil, err
@@ -21,7 +21,7 @@ func DecodeJSON(r io.Reader) ([]*Span, error) {
 	return spans, nil
 }
 
-type zipkinJSONSpan struct {
+type ZipkinJSONSpan struct {
 	TraceID           string              `json:"traceId"`
 	Name              string              `json:"name"`
 	ID                string              `json:"id"`
@@ -33,7 +33,7 @@ type zipkinJSONSpan struct {
 	Duration          int64               `json:"duration,omitempty"`
 }
 
-func convertJSONSpan(zs zipkinJSONSpan) *Span {
+func convertJSONSpan(zs ZipkinJSONSpan) *Span {
 	s := &Span{
 		CoreSpanMetadata: CoreSpanMetadata{
 			TraceID:    zs.TraceID,


### PR DESCRIPTION
Similarly to #8, we look for a `honeycomb.samplerate` tag, and use its
value as the sample rate when sending events to Honeycomb. Note that the
proxy doesn't do any *additional* sampling itself; it still forwards all the
spans it gets.

The main benefit is that you can now send a sampled set of traces and get 
accurate(ish) results for aggregate queries.

Test plan: unit tests