### PR TITLE
Clean up logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/honeycombio/honeycomb-opentracing-proxy/app"
 	"github.com/honeycombio/honeycomb-opentracing-proxy/sinks"
 	flag "github.com/jessevdk/go-flags"
@@ -52,6 +53,7 @@ func main() {
 	)
 	if options.Debug {
 		sink.Add(&sinks.StdoutSink{})
+		logrus.SetLevel(logrus.DebugLevel)
 	}
 
 	sink.Start()


### PR DESCRIPTION
Previously, logging in the opentracing proxy gwas a bit underwhelming --
in particular, if you got an error back from the Honeycomb API, it'd be
logged as hex-encoded bytes :(

It'd still be good to add opt-in telemetry. Soon!