### PR TITLE
Correct Zipkin terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 `honeycomb-opentracing-proxy` is a drop-in compatible replacement for Zipkin.
 If your services are instrumented with OpenTracing and emit span data using
-Zipkin's wire format, then `honeycomb-opentracing-proxy` can receive that data
-and forward it to the [Honeycomb](https://honeycomb.io) API. Using Honeycomb,
-you can explore single traces, and run queries over aggregated trace data.
+Zipkin's Thrift based reporting format, then `honeycomb-opentracing-proxy` can
+receive that data and forward it to the [Honeycomb](https://honeycomb.io) API. 
+Using Honeycomb, you can explore single traces, and run queries over aggregated 
+trace data.
 
 <img src="docs/flow.png" alt="flow diagram" width="75%">
 


### PR DESCRIPTION
I'm tempted to put the word legacy right before Thrift in that sentence, since we have newer more efficient encodings for zipkin right now.

Also, I'm not sure what OpenTracing means in this context since encoding has no dependency on how things are instrumented, and OT does not define nor even guarantee the ability to encode to Zipkin Thrift. This would more correctly mention Zipkin and others (Jaeger, SkyWalking) that have implemented this Zipkin Thrift encoding directly instead of OT