### PR TITLE
Fix endpoints in JSON spans

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -212,7 +212,7 @@ func TestHoneycombOutput(t *testing.T) {
 					{
 						"key": "lc",
 						"value": "poodle",
-						"host": {
+						"endpoint": {
 							"ipv4": "10.129.211.111",
 							"serviceName": "poodle"
 						}
@@ -220,7 +220,7 @@ func TestHoneycombOutput(t *testing.T) {
 					{
 						"key": "responseLength",
 						"value": "136",
-						"host": {
+						"endpoint": {
 							"ipv4": "10.129.211.111",
 							"serviceName": "poodle"
 						}
@@ -258,7 +258,7 @@ func TestHoneycombSinkTagHandling(t *testing.T) {
 			{
 				"key": "lc",
 				"value": "shepherd",
-				"host": {
+				"endpoint": {
 					"ipv4": "10.129.211.121",
 					"serviceName": "shepherd"
 				}
@@ -266,7 +266,7 @@ func TestHoneycombSinkTagHandling(t *testing.T) {
 			{
 				"key": "keyToDrop",
 				"value": "secret",
-				"host": {
+				"endpoint": {
 					"ipv4": "10.129.211.121",
 					"serviceName": "shepherd"
 				}
@@ -274,7 +274,7 @@ func TestHoneycombSinkTagHandling(t *testing.T) {
 			{
 				"key": "honeycomb.dataset",
 				"value": "write-traces",
-				"host": {
+				"endpoint": {
 					"ipv4": "10.129.211.121",
 					"serviceName": "shepherd"
 				}
@@ -282,7 +282,7 @@ func TestHoneycombSinkTagHandling(t *testing.T) {
 			{
 				"key": "honeycomb.samplerate",
 				"value": "22",
-				"host": {
+				"endpoint": {
 					"ipv4": "10.129.211.121",
 					"serviceName": "shepherd"
 				}

--- a/types/json.go
+++ b/types/json.go
@@ -89,13 +89,13 @@ func convertJSONSpan(zs ZipkinJSONSpan) *Span {
 type Annotation struct {
 	Timestamp int64     `json:"timestamp"`
 	Value     string    `json:"value"`
-	Host      *Endpoint `json:"host,omitempty"`
+	Host      *Endpoint `json:"endpoint,omitempty"`
 }
 
 type binaryAnnotation struct {
 	Key      string    `json:"key"`
 	Value    string    `json:"value"`
-	Endpoint *Endpoint `json:"host,omitempty"`
+	Endpoint *Endpoint `json:"endpoint,omitempty"`
 }
 
 type Endpoint struct {


### PR DESCRIPTION
The original implementation would look for a `"host"` key instead of an
`"endpoint"` key in JSON spans. This was a plain mistake rather than a
compatibility measure; fix it.