### PR TITLE
add support for gzipped POST bodies

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
 	"io"
@@ -71,9 +72,35 @@ func (a *App) handleSpans(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
 }
 
+// ungzipWrap wraps a handleFunc and transparently ungzips the body of the
+// request if it is gzipped
+func ungzipWrap(hf func(http.ResponseWriter, *http.Request)) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var newBody io.ReadCloser
+		isGzipped := r.Header.Get("Content-Encoding")
+		if isGzipped == "gzip" {
+			buf := bytes.Buffer{}
+			if _, err := io.Copy(&buf, r.Body); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte("error allocating buffer for ungzipping"))
+				return
+			}
+			var err error
+			newBody, err = gzip.NewReader(&buf)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte("error ungzipping span data"))
+				return
+			}
+			r.Body = newBody
+		}
+		hf(w, r)
+	}
+}
+
 func (a *App) Start() error {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/spans", a.handleSpans)
+	mux.HandleFunc("/api/v1/spans", ungzipWrap(a.handleSpans))
 
 	a.server = &http.Server{
 		Addr:    a.Port,

--- a/app/app.go
+++ b/app/app.go
@@ -81,6 +81,7 @@ func ungzipWrap(hf func(http.ResponseWriter, *http.Request)) func(http.ResponseW
 		if isGzipped == "gzip" {
 			buf := bytes.Buffer{}
 			if _, err := io.Copy(&buf, r.Body); err != nil {
+				logrus.WithError(err).Info("error allocating buffer for ungzipping")
 				w.WriteHeader(http.StatusBadRequest)
 				w.Write([]byte("error allocating buffer for ungzipping"))
 				return
@@ -88,6 +89,7 @@ func ungzipWrap(hf func(http.ResponseWriter, *http.Request)) func(http.ResponseW
 			var err error
 			newBody, err = gzip.NewReader(&buf)
 			if err != nil {
+				logrus.WithError(err).Info("error ungzipping span data")
 				w.WriteHeader(http.StatusBadRequest)
 				w.Write([]byte("error ungzipping span data"))
 				return


### PR DESCRIPTION
Got a support request from ballerina.io sending data to the proxy, turned out they were sending zipped data and getting a confusing error back: "invalid character '\\x1f' looking for beginning of value". This change adds support for decompressing gzipped bodies when the Content-Encoding header is set to 'gzip'.