### PR TITLE
Convert zero parentIDs to nils in thrift decoder

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -129,6 +129,35 @@ func TestThriftDecoding(t *testing.T) {
 	assert.Equal(w.Code, http.StatusAccepted)
 }
 
+func TestThriftRootSpans(t *testing.T) {
+	// Test that spans with a *zero* parentID get converted to spans with a nil
+	// parentID.
+	assert := assert.New(t)
+	var zero int64
+	body := serializeThriftSpans([]*zipkincore.Span{
+		&zipkincore.Span{
+			TraceID:  2222,
+			ID:       2222,
+			ParentID: &zero,
+			Name:     "mySpan",
+		},
+	})
+	ms := &MockSink{}
+	a := &App{Sink: ms}
+	w := handle(a, body, "application/x-thrift")
+	assert.Equal(w.Code, http.StatusAccepted)
+	assert.Equal(ms.spans[0], types.Span{
+		CoreSpanMetadata: types.CoreSpanMetadata{
+			TraceID:      "8ae",
+			TraceIDAsInt: 2222,
+			ID:           "8ae",
+			ParentID:     "",
+			Name:         "mySpan",
+		},
+		BinaryAnnotations: map[string]interface{}{},
+	})
+}
+
 // TestMirroring tests the mirroring of unmodified request data to a downstream
 // service.
 func TestMirroring(t *testing.T) {

--- a/types/thrift.go
+++ b/types/thrift.go
@@ -23,7 +23,7 @@ func convertThriftSpan(ts *zipkincore.Span) *Span {
 		},
 		BinaryAnnotations: make(map[string]interface{}, len(ts.BinaryAnnotations)),
 	}
-	if ts.ParentID != nil {
+	if ts.ParentID != nil && *ts.ParentID != 0 {
 		s.ParentID = convertID(*ts.ParentID)
 	}
 


### PR DESCRIPTION
The Jaeger Java client (and possibly others?) set `parentID: 0` instead
of `parentID: nil` when serializing root spans.[1] Convert this to
`parentID: nil`, which works better with the trace UI / starter queries

[1] https://github.com/jaegertracing/jaeger-client-java/blob/0ece0fd895b5/jaeger-thrift/src/main/java/io/jaegertracing/thrift/reporters/protocols/JaegerThriftSpanConverter.java#L46