### PR TITLE
default missing timestamps to the current timestamp

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -183,7 +183,7 @@ func TestThriftRootSpans(t *testing.T) {
 	// Test that spans with a *zero* parentID get converted to spans with a nil
 	// parentID.
 	assert := assert.New(t)
-	now := time.Now().UTC()
+	now := time.Now().UTC().Round(time.Microsecond)
 	n := now.UnixNano() / int64(time.Microsecond)
 	var zero int64
 	body := serializeThriftSpans([]*zipkincore.Span{
@@ -207,7 +207,7 @@ func TestThriftRootSpans(t *testing.T) {
 			ParentID:     "",
 			Name:         "mySpan",
 		},
-		Timestamp:         now.Round(time.Microsecond),
+		Timestamp:         now,
 		BinaryAnnotations: map[string]interface{}{},
 	}, ms.spans[0])
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -199,7 +199,7 @@ func TestThriftRootSpans(t *testing.T) {
 	a := &App{Sink: ms}
 	w := handle(a, body, "application/x-thrift")
 	assert.Equal(w.Code, http.StatusAccepted)
-	assert.Equal(ms.spans[0], types.Span{
+	assert.Equal(types.Span{
 		CoreSpanMetadata: types.CoreSpanMetadata{
 			TraceID:      "8ae",
 			TraceIDAsInt: 2222,
@@ -209,7 +209,7 @@ func TestThriftRootSpans(t *testing.T) {
 		},
 		Timestamp:         now.Round(time.Microsecond),
 		BinaryAnnotations: map[string]interface{}{},
-	})
+	}, ms.spans[0])
 }
 
 // TestMirroring tests the mirroring of unmodified request data to a downstream

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -207,7 +207,7 @@ func TestThriftRootSpans(t *testing.T) {
 			ParentID:     "",
 			Name:         "mySpan",
 		},
-		Timestamp:         now,
+		Timestamp:         now.Round(time.Microsecond),
 		BinaryAnnotations: map[string]interface{}{},
 	})
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -69,9 +69,9 @@ func TestMissingThriftTimestampHandling(t *testing.T) {
 
 	thriftPayload := serializeThriftSpans([]*zipkincore.Span{
 		&zipkincore.Span{
-			TraceID:  2222,
-			ID:       2222,
-			Name:     "mySpan",
+			TraceID: 2222,
+			ID:      2222,
+			Name:    "mySpan",
 		},
 	})
 
@@ -188,10 +188,10 @@ func TestThriftRootSpans(t *testing.T) {
 	var zero int64
 	body := serializeThriftSpans([]*zipkincore.Span{
 		&zipkincore.Span{
-			TraceID:  2222,
-			ID:       2222,
-			ParentID: &zero,
-			Name:     "mySpan",
+			TraceID:   2222,
+			ID:        2222,
+			ParentID:  &zero,
+			Name:      "mySpan",
 			Timestamp: &n,
 		},
 	})
@@ -207,7 +207,7 @@ func TestThriftRootSpans(t *testing.T) {
 			ParentID:     "",
 			Name:         "mySpan",
 		},
-		Timestamp: now,
+		Timestamp:         now,
 		BinaryAnnotations: map[string]interface{}{},
 	})
 }

--- a/types/span.go
+++ b/types/span.go
@@ -38,6 +38,10 @@ type CoreSpanMetadata struct {
 // convertTimestamp turns a Zipkin timestamp (a Unix timestamp in microseconds)
 // into a time.Time value.
 func convertTimestamp(tsMicros int64) time.Time {
+	if tsMicros == 0 {
+		return time.Now().UTC()
+	}
+
 	return time.Unix(tsMicros/1000000, (tsMicros%1000000)*1000).UTC()
 }
 

--- a/types/thrift.go
+++ b/types/thrift.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
+	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/uber/jaeger/thrift-gen/zipkincore"
@@ -33,6 +34,8 @@ func convertThriftSpan(ts *zipkincore.Span) *Span {
 
 	if ts.Timestamp != nil {
 		s.Timestamp = convertTimestamp(*ts.Timestamp)
+	} else {
+		s.Timestamp = time.Now().UTC()
 	}
 
 	var endpoint *zipkincore.Endpoint


### PR DESCRIPTION
If we receive a JSON or thrift payload that is missing a timestamp we now default it to the current timestamp