### PR TITLE
Port tracing fields to new names

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -318,14 +318,14 @@ func TestHoneycombOutput(t *testing.T) {
 	assert.Equal(len(mockHoneycomb.Events()), 1)
 	assert.Equal(mockHoneycomb.Events()[0].Fields(),
 		map[string]interface{}{
-			"traceId":        "350565b6a90d4c8c",
+			"trace.trace_id": "350565b6a90d4c8c",
 			"name":           "persist",
-			"id":             "34472e70cb669b31",
-			"serviceName":    "poodle",
-			"hostIPv4":       "10.129.211.111",
+			"trace.span_id":  "34472e70cb669b31",
+			"service_name":   "poodle",
+			"host_ipv4":      "10.129.211.111",
 			"lc":             "poodle",
 			"responseLength": int64(136),
-			"durationMs":     0.192,
+			"duration_ms":    0.192,
 		})
 	assert.Equal(mockHoneycomb.Events()[0].Dataset, "test")
 }
@@ -400,13 +400,13 @@ func TestHoneycombSinkTagHandling(t *testing.T) {
 	assert.Equal(mockHoneycomb.Events()[0].SampleRate, uint(22))
 	assert.Equal(mockHoneycomb.Events()[0].Fields(),
 		map[string]interface{}{
-			"id":          "bb433fd338b2cecb",
-			"traceId":     "8fe5ac327a4a4a88",
-			"name":        "persist",
-			"hostIPv4":    "10.129.211.121",
-			"serviceName": "shepherd",
-			"durationMs":  0.222,
-			"lc":          "shepherd",
+			"trace.span_id":  "bb433fd338b2cecb",
+			"trace.trace_id": "8fe5ac327a4a4a88",
+			"name":           "persist",
+			"host_ipv4":      "10.129.211.121",
+			"service_name":   "shepherd",
+			"duration_ms":    0.222,
+			"lc":             "shepherd",
 		})
 
 	sampleSpan.BinaryAnnotations[3].Value = "-22"
@@ -467,7 +467,7 @@ func TestSampling(t *testing.T) {
 
 	sampledSpanCounts := make(map[string]int)
 	for _, ev := range mockHoneycomb.Events() {
-		sampledSpanCounts[ev.Fields()["traceId"].(string)]++
+		sampledSpanCounts[ev.Fields()["trace.trace_id"].(string)]++
 	}
 
 	// Check that we sent 3 out of 30 traces, and that each trace has a

--- a/types/span.go
+++ b/types/span.go
@@ -15,7 +15,7 @@ import (
 type Span struct {
 	CoreSpanMetadata
 	Annotations       []*Annotation          `json:"annotations,omitempty"` // TODO lift annotation struct definition into this file
-	BinaryAnnotations map[string]interface{} `json:"binaryAnnotations,omitempty"`
+	BinaryAnnotations map[string]interface{} `json:"binary_annotations,omitempty"`
 	Timestamp         time.Time              `json:"timestamp,omitempty"`
 }
 
@@ -23,16 +23,16 @@ type Span struct {
 // a libhoney event. Annotations, BinaryAnnotations and Timestamp need special
 // handling.
 type CoreSpanMetadata struct {
-	TraceID      string  `json:"traceId"`
+	TraceID      string  `json:"trace.trace_id"`
 	TraceIDAsInt int64   `json:"-"` // Zipkin trace ID as integer; not added to events, but used for sampling decisions
 	Name         string  `json:"name"`
-	ID           string  `json:"id"`
-	ParentID     string  `json:"parentId,omitempty"`
-	ServiceName  string  `json:"serviceName,omitempty"`
-	HostIPv4     string  `json:"hostIPv4,omitempty"`
+	ID           string  `json:"trace.span_id"`
+	ParentID     string  `json:"trace.parent_id,omitempty"`
+	ServiceName  string  `json:"service_name,omitempty"`
+	HostIPv4     string  `json:"host_ipv4,omitempty"`
 	Port         int     `json:"port,omitempty"`
 	Debug        bool    `json:"debug,omitempty"`
-	DurationMs   float64 `json:"durationMs,omitempty"`
+	DurationMs   float64 `json:"duration_ms,omitempty"`
 }
 
 // convertTimestamp turns a Zipkin timestamp (a Unix timestamp in microseconds)


### PR DESCRIPTION
Closes https://github.com/honeycombio/honeycomb-opentracing-proxy/issues/34

⚠️ BREAKING CHANGE ⚠️ 

I will sketch up a plan to notify users who might potentially update their proxy if this is merged.

This should provide compatibility with Beeline fields and OpenCensus emitted fields.