### PR TITLE
Ensure ConvertID always returns positive hex values

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -201,9 +201,9 @@ func TestThriftRootSpans(t *testing.T) {
 	assert.Equal(w.Code, http.StatusAccepted)
 	assert.Equal(types.Span{
 		CoreSpanMetadata: types.CoreSpanMetadata{
-			TraceID:      "8ae",
+			TraceID:      "00000000000008ae",
 			TraceIDAsInt: 2222,
-			ID:           "8ae",
+			ID:           "00000000000008ae",
 			ParentID:     "",
 			Name:         "mySpan",
 		},

--- a/types/thrift.go
+++ b/types/thrift.go
@@ -72,7 +72,7 @@ func convertThriftSpan(ts *zipkincore.Span) *Span {
 }
 
 func convertID(id int64) string {
-	return fmt.Sprintf("%x", id) // TODO is this right?
+	return fmt.Sprintf("%016x", uint64(id))
 }
 
 func convertIPv4(ip int32) string {


### PR DESCRIPTION
For some spans, we were seeing negative trace IDs,
even though other spans in the same trace returned
positive trace IDs. This caused the trace to be split
in two

Ensure that the trace ID is also zero padded for
consistency