### PR TITLE
add version to user agent

### DIFF
--- a/DEVELOPMENT.MD
+++ b/DEVELOPMENT.MD
@@ -1,0 +1,3 @@
+## Version
+
+When making a change to Honeycomb OpenTracing Proxy, update the version number in [/sinks/honeycomb.go](./sinks/honeycomb.go)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ you can explore single traces, and run queries over aggregated trace data.
 First, [sign up](https://honeycomb.io/signup) for a free Honeycomb trial
 account, and grab your write key from your [account page](https://ui.honeycomb.io/account).
 
-
 ### Installation
 
 If you have Go installed, you can clone this repository and build the
@@ -60,3 +59,7 @@ If your outbound HTTP traffic goes through an internal/corporate proxy server, y
 ```
 HTTPS_PROXY=<my proxy address>
 ```
+
+## Looking to contribute?
+
+Please see our [development guide](./DEVELOPMENT.md)

--- a/sinks/honeycomb.go
+++ b/sinks/honeycomb.go
@@ -26,7 +26,8 @@ func (hs *HoneycombSink) Start() error {
 	for _, v := range hs.DropFields {
 		hs.dropFieldsMap[v] = struct{}{}
 	}
-	libhoney.UserAgentAddition = "honeycomb-opentracing-proxy"
+	versionStr := "1.0.1"
+	libhoney.UserAgentAddition = "honeycomb-opentracing-proxy" + versionStr
 	libhoney.Init(libhoney.Config{
 		WriteKey: hs.Writekey,
 		Dataset:  hs.Dataset,

--- a/sinks/honeycomb.go
+++ b/sinks/honeycomb.go
@@ -27,7 +27,7 @@ func (hs *HoneycombSink) Start() error {
 		hs.dropFieldsMap[v] = struct{}{}
 	}
 	versionStr := "1.0.1"
-	libhoney.UserAgentAddition = "honeycomb-opentracing-proxy" + versionStr
+	libhoney.UserAgentAddition = "honeycomb-opentracing-proxy/" + versionStr
 	libhoney.Init(libhoney.Config{
 		WriteKey: hs.Writekey,
 		Dataset:  hs.Dataset,


### PR DESCRIPTION
It would be nice to see what version people are running.
This adds the version string to the user agent.
It also adds a bit of documentation in hopes that people will remember to bump it when making changes.

Set it to 1.0.1 here and will release a version once this is merged.