### PR TITLE
Allow any type of value in binnaryAnnotation

### DIFF
--- a/types/json.go
+++ b/types/json.go
@@ -93,9 +93,9 @@ type Annotation struct {
 }
 
 type binaryAnnotation struct {
-	Key      string    `json:"key"`
-	Value    string    `json:"value"`
-	Endpoint *Endpoint `json:"endpoint,omitempty"`
+	Key      string      `json:"key"`
+	Value    interface{} `json:"value"`
+	Endpoint *Endpoint   `json:"endpoint,omitempty"`
 }
 
 type Endpoint struct {

--- a/types/span.go
+++ b/types/span.go
@@ -45,20 +45,31 @@ func convertTimestamp(tsMicros int64) time.Time {
 	return time.Unix(tsMicros/1000000, (tsMicros%1000000)*1000).UTC()
 }
 
-// guessAnnotationType takes a string value and turns it into a bool, int64 or
-// float64 value if possible. This is a workaround for the fact that Zipkin
-// BinaryAnnotation values are always transmitted as strings.
+// guessAnnotationType takes a value and, if it is a string, turns it into a bool,
+// int64 or float64 value when possible. This is a workaround for the fact that
+// Zipkin v1 BinaryAnnotation values are always transmitted as strings.
 // (See e.g. the Zipkin API spec here:
 // https://github.com/openzipkin/zipkin-api/blob/72280f3/zipkin-api.yaml#L235-L245)
-func guessAnnotationType(v string) interface{} {
-	if v == "false" {
-		return false
-	} else if v == "true" {
-		return true
-	} else if intVal, err := strconv.ParseInt(v, 10, 64); err == nil {
-		return intVal
-	} else if floatVal, err := strconv.ParseFloat(v, 64); err == nil {
-		return floatVal
+//
+// However it considers the possibility that the value is not a string in case the
+// BinaryAnnotation does not implement the Zipkin API v1 spec. In this case it
+// will just return the same value, without modifying it. See this issue
+// for such an example:
+// https://github.com/honeycombio/honeycomb-opentracing-proxy/issues/37
+func guessAnnotationType(v interface{}) interface{} {
+	switch v.(type) {
+	default:
+		return v
+	case string:
+		if v.(string) == "false" {
+			return false
+		} else if v.(string) == "true" {
+			return true
+		} else if intVal, err := strconv.ParseInt(v.(string), 10, 64); err == nil {
+			return intVal
+		} else if floatVal, err := strconv.ParseFloat(v.(string), 64); err == nil {
+			return floatVal
+		}
 	}
 
 	return v

--- a/types/span.go
+++ b/types/span.go
@@ -57,20 +57,17 @@ func convertTimestamp(tsMicros int64) time.Time {
 // for such an example:
 // https://github.com/honeycombio/honeycomb-opentracing-proxy/issues/37
 func guessAnnotationType(v interface{}) interface{} {
-	switch v.(type) {
-	default:
+	strVal, ok := v.(string)
+	if !ok {
 		return v
-	case string:
-		if v.(string) == "false" {
-			return false
-		} else if v.(string) == "true" {
-			return true
-		} else if intVal, err := strconv.ParseInt(v.(string), 10, 64); err == nil {
-			return intVal
-		} else if floatVal, err := strconv.ParseFloat(v.(string), 64); err == nil {
-			return floatVal
-		}
+	} else if strVal == "false" {
+		return false
+	} else if strVal == "true" {
+		return true
+	} else if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
+		return intVal
+	} else if floatVal, err := strconv.ParseFloat(strVal, 64); err == nil {
+		return floatVal
 	}
-
-	return v
+	return strVal
 }


### PR DESCRIPTION
Change binaryAnnotation Value from string to interface{} so it can take any kind of value. If it is a string, if will still try to parse it into a boolean, integer or float. If not, it will simply not attempt to unmarshal it into a string, and leave it as is.

Although apparently Zipkin v1 api binaryAnnotation values should be string only, some libraries do not always respect this. See this issue for an example: https://github.com/honeycombio/honeycomb-opentracing-proxy/issues/37 (this PR should probably fix that issue).

I had a similar issue using https://github.com/openzipkin/brave/tree/master/brave#zipkin-v1-setup

