### PR TITLE
Ensure Zipkin V2 API requests are forwarded to V2 downstream API.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -19,6 +19,9 @@ import (
 	v2 "github.com/honeycombio/honeycomb-opentracing-proxy/types/v2"
 )
 
+const V1Endpoint string = "/api/v1/spans"
+const V2Endpoint string = "/api/v2/spans"
+
 type App struct {
 	Port   string
 	server *http.Server
@@ -43,7 +46,7 @@ func (a *App) handleSpansV1(w http.ResponseWriter, r *http.Request) {
 	contentType := r.Header.Get("Content-Type")
 
 	if a.Mirror != nil {
-		if err := a.Mirror.Send(payload{Endpoint: "/api/v1/spans", ContentType: contentType, Body: data}); err != nil {
+		if err := a.Mirror.Send(payload{Endpoint: V1Endpoint, ContentType: contentType, Body: data}); err != nil {
 			logrus.WithError(err).Info("Error mirroring data")
 		}
 	}
@@ -90,7 +93,7 @@ func (a *App) handleSpansV2(w http.ResponseWriter, r *http.Request) {
 	contentType := r.Header.Get("Content-Type")
 
 	if a.Mirror != nil {
-		if err := a.Mirror.Send(payload{Endpoint: "/api/v2/spans", ContentType: contentType, Body: data}); err != nil {
+		if err := a.Mirror.Send(payload{Endpoint: V2Endpoint, ContentType: contentType, Body: data}); err != nil {
 			logrus.WithError(err).Info("Error mirroring data")
 		}
 	}
@@ -148,8 +151,8 @@ func ungzipWrap(hf func(http.ResponseWriter, *http.Request)) func(http.ResponseW
 
 func (a *App) Start() error {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/spans", ungzipWrap(a.handleSpansV1))
-	mux.HandleFunc("/api/v2/spans", ungzipWrap(a.handleSpansV2))
+	mux.HandleFunc(V1Endpoint, ungzipWrap(a.handleSpansV1))
+	mux.HandleFunc(V2Endpoint, ungzipWrap(a.handleSpansV2))
 
 	a.server = &http.Server{
 		Addr:    a.Port,

--- a/app/app.go
+++ b/app/app.go
@@ -43,7 +43,7 @@ func (a *App) handleSpansV1(w http.ResponseWriter, r *http.Request) {
 	contentType := r.Header.Get("Content-Type")
 
 	if a.Mirror != nil {
-		if err := a.Mirror.Send(payload{ContentType: contentType, Body: data}); err != nil {
+		if err := a.Mirror.Send(payload{Endpoint: "/api/v1/spans", ContentType: contentType, Body: data}); err != nil {
 			logrus.WithError(err).Info("Error mirroring data")
 		}
 	}
@@ -90,7 +90,7 @@ func (a *App) handleSpansV2(w http.ResponseWriter, r *http.Request) {
 	contentType := r.Header.Get("Content-Type")
 
 	if a.Mirror != nil {
-		if err := a.Mirror.Send(payload{ContentType: contentType, Body: data}); err != nil {
+		if err := a.Mirror.Send(payload{Endpoint: "/api/v2/spans", ContentType: contentType, Body: data}); err != nil {
 			logrus.WithError(err).Info("Error mirroring data")
 		}
 	}
@@ -167,6 +167,7 @@ func (a *App) Stop() error {
 }
 
 type payload struct {
+	Endpoint    string
 	ContentType string
 	Body        []byte
 }
@@ -208,7 +209,9 @@ func (m *Mirror) Stop() error {
 
 func (m *Mirror) runWorker() {
 	for p := range m.payloads {
-		r, err := http.NewRequest("POST", m.DownstreamURL.String(), bytes.NewReader(p.Body))
+		downstreamURL := m.DownstreamURL
+		downstreamURL.Path = p.Endpoint
+		r, err := http.NewRequest("POST", downstreamURL.String(), bytes.NewReader(p.Body))
 		r.Header.Set("Content-Type", p.ContentType)
 		if err != nil {
 			logrus.WithError(err).Info("Error building downstream request")

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -270,7 +270,7 @@ func TestMirroring(t *testing.T) {
 	mirror.Stop()
 
 	assert.Equal(len(m.payloads), 1)
-	assert.Equal(m.payloads[0].Endpoint, "/api/v1/spans")
+	assert.Equal(m.payloads[0].Endpoint, V1Endpoint)
 	assert.Equal(m.payloads[0].Body, data)
 	assert.Equal(m.payloads[0].ContentType, "application/x-thrift")
 }
@@ -309,7 +309,7 @@ func TestMirroringV2(t *testing.T) {
 	mirror.Stop()
 
 	assert.Equal(len(m.payloads), 1)
-	assert.Equal(m.payloads[0].Endpoint, "/api/v2/spans")
+	assert.Equal(m.payloads[0].Endpoint, V2Endpoint)
 	assert.Equal(m.payloads[0].Body, data)
 	assert.Equal(m.payloads[0].ContentType, "application/json")
 }
@@ -684,7 +684,7 @@ func newMockDownstream() *mockDownstream {
 }
 
 func handleV1(a *App, payload []byte, contentType string) *httptest.ResponseRecorder {
-	r := httptest.NewRequest("POST", "/api/v1/spans", bytes.NewReader(payload))
+	r := httptest.NewRequest("POST", V1Endpoint, bytes.NewReader(payload))
 	r.Header.Add("Content-Type", contentType)
 	w := httptest.NewRecorder()
 	a.handleSpansV1(w, r)
@@ -692,7 +692,7 @@ func handleV1(a *App, payload []byte, contentType string) *httptest.ResponseReco
 }
 
 func handleV2(a *App, payload []byte, contentType string) *httptest.ResponseRecorder {
-	r := httptest.NewRequest("POST", "/api/v2/spans", bytes.NewReader(payload))
+	r := httptest.NewRequest("POST", V2Endpoint, bytes.NewReader(payload))
 	r.Header.Add("Content-Type", contentType)
 	w := httptest.NewRecorder()
 	a.handleSpansV2(w, r)
@@ -705,7 +705,7 @@ func handleGzippedV1(a *App, payload []byte, contentType string) *httptest.Respo
 	zw.Write(payload)
 	zw.Close()
 
-	r := httptest.NewRequest("POST", "/api/v1/spans", &compressedPayload)
+	r := httptest.NewRequest("POST", V1Endpoint, &compressedPayload)
 	r.Header.Add("Content-Encoding", "gzip")
 	r.Header.Add("Content-Type", contentType)
 	w := httptest.NewRecorder()
@@ -719,7 +719,7 @@ func handleGzippedV2(a *App, payload []byte, contentType string) *httptest.Respo
 	zw.Write(payload)
 	zw.Close()
 
-	r := httptest.NewRequest("POST", "/api/v2/spans", &compressedPayload)
+	r := httptest.NewRequest("POST", V2Endpoint, &compressedPayload)
 	r.Header.Add("Content-Encoding", "gzip")
 	r.Header.Add("Content-Type", contentType)
 	w := httptest.NewRecorder()

--- a/app/testdata/payload_1.json
+++ b/app/testdata/payload_1.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "352bff9a74ca9ad2",
+    "traceId": "5af7183fb1d4cf5f",
+    "parentId": "6b221d5bc9e6496c",
+    "name": "get /api",
+    "timestamp": 1556604172355737,
+    "duration": 1431,
+    "kind": "SERVER",
+    "localEndpoint": {
+      "serviceName": "backend",
+      "ipv4": "192.168.99.1",
+      "port": 3306
+    },
+    "remoteEndpoint": {
+      "ipv4": "172.19.0.2",
+      "port": 58648
+    },
+    "tags": {
+      "http.method": "GET",
+      "http.path": "/api"
+    }
+  }
+]

--- a/main.go
+++ b/main.go
@@ -74,7 +74,6 @@ func main() {
 			os.Exit(1)
 		}
 
-		downstreamURL.Path = "/api/v1/spans"
 		mirror = &app.Mirror{
 			DownstreamURL: downstreamURL,
 		}


### PR DESCRIPTION
Fixes #45.

May I ask for a thorough review from maintainers on this one? I'm not particularly proficient in golang.